### PR TITLE
判定条件をエラーメッセージに合うように修正 #13

### DIFF
--- a/fruitsales/models.py
+++ b/fruitsales/models.py
@@ -29,7 +29,7 @@ def generate_sales_from_csv(file):
     records = csv.reader(records_csv, delimiter=',')
     sale_list = []
     for row in records:
-        if len(row) < 4:
+        if len(row) != 4:
             raise ValidationError('要素数が４以外です: ' + ','.join(row))
 
         # Fruitオブジェクトを取得


### PR DESCRIPTION
変更前：判定条件とエラーメッセージに齟齬
変更後：論理的にはエラーメッセージの方が適切なので判定条件を修正